### PR TITLE
Feature/search improvements

### DIFF
--- a/search-replace.css
+++ b/search-replace.css
@@ -1,6 +1,6 @@
 #searchbar-wrapper {
   position: absolute;
-  background-color: #ffffff;
+  background-color: LightGoldenRodYellow;
   border-style: solid;
   border-radius: 5px;
   border-color: #aaaaaa;
@@ -24,15 +24,48 @@
   padding: 6px 2px 6px 2px;
 }
 
+
+/* -------------------------------------------------------------------------- */
+
 .btn-group button {
   margin-top: 2px;
   margin-right: 2px;
+}
+
+.btn-group button#searchbar_search {
+  float: right;
+}
+
+.btn-group button#searchbar_wrap.active {
+  background-color: green;
+}
+
+.btn-group button#searchbar_case_sensitive.active {
+  background-color: green;
+}
+
+/* -------------------------------------------------------------------------- */
+
+div#searchbar-wrapper.notfound  {
+    background-color: orange;
 }
 
 .btn-group button.notfound {
   background-color: red;
 }
 
-button#searchbar_search {
-  float: right;
+/* -------------------------------------------------------------------------- */
+/* not working yet */
+
+div#searchbar-wrapper.searching  {
+    background-color: lightgray;
 }
+
+.btn-group button.searching {
+  background-color: gray;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* Default selection highlight is too dull */
+.CodeMirror-selected { background: yellow !important; }

--- a/search-replace.css
+++ b/search-replace.css
@@ -55,7 +55,7 @@ div#searchbar-wrapper.notfound  {
 }
 
 /* -------------------------------------------------------------------------- */
-/* not working yet */
+/* aspect while the extension is searching */
 
 div#searchbar-wrapper.searching  {
     background-color: lightgray;


### PR DESCRIPTION
Improvements & fixes in search-replace extension:
* fix: don't trigger search on key events with 0 keycode (e.g. dead keys)
* fix: render back Markdown cells after searching (only in previously rendered, and not for cell matches)
* improve saliency of selection (with CSS)
* improve saliency of 'notfound' event (with CSS)
* search box greyed out while searching is taking place




